### PR TITLE
Add quantum simulator and test

### DIFF
--- a/cryptoquantum/__init__.py
+++ b/cryptoquantum/__init__.py
@@ -7,5 +7,6 @@ apenas e **não deve** ser utilizado em cenários de produção.
 
 from . import pqc  # Reexporta módulo de funções de exemplo
 from . import qubit  # Define classe Qubit ilustrativa
+from . import simulator  # Simulador qu\u00e2ntico simplificado
 
-__all__ = ["pqc", "qubit"]
+__all__ = ["pqc", "qubit", "simulator"]

--- a/cryptoquantum/qubit.py
+++ b/cryptoquantum/qubit.py
@@ -39,6 +39,10 @@ class Qubit:
         self.alpha, self.beta = a, b
         self.normalize()
 
+    def apply_x(self) -> None:
+        """Aplica a porta Pauli-X (bit flip)."""
+        self.alpha, self.beta = self.beta, self.alpha
+
     def measure(self) -> int:
         """Mede o qubit e colapsa o estado retornando 0 ou 1."""
         p0 = abs(self.alpha) ** 2

--- a/cryptoquantum/simulator.py
+++ b/cryptoquantum/simulator.py
@@ -1,0 +1,51 @@
+"""Simulador qu\u00e2ntico simplificado.
+
+Este m\u00f3dulo prov\u00ea uma classe :class:`QuantumSimulator` que utiliza o
+modelo de :class:`~cryptoquantum.qubit.Qubit` para demonstrar, de forma
+b\u00e1sica, opera\u00e7\u00f5es de encripta\u00e7\u00e3o e decripta\u00e7\u00e3o.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from . import pqc
+from .qubit import Qubit
+
+
+def _bits_from_byte(value: int) -> list[int]:
+    """Converte um byte em uma lista de bits (LSB primeiro)."""
+    return [(value >> i) & 1 for i in range(8)]
+
+
+def _byte_from_bits(bits: Iterable[int]) -> int:
+    """Converte uma sequ\u00eancia de bits em um byte."""
+    result = 0
+    for i, bit in enumerate(bits):
+        result |= (bit & 1) << i
+    return result
+
+
+class QuantumSimulator:
+    """Pequeno simulador para opera\u00e7\u00f5es de criptografia."""
+
+    def encrypt(self, key: bytes, plaintext: bytes) -> bytes:
+        """Encripta dados aplicando opera\u00e7\u00f5es qu\u00e2nticas simples."""
+        resultado = bytearray()
+        for idx, byte in enumerate(plaintext):
+            chave = key[idx % pqc.KEY_SIZE]
+            bits_cifrados = []
+            for b, k in zip(_bits_from_byte(byte), _bits_from_byte(chave)):
+                q = Qubit(alpha=1 + 0j, beta=0 + 0j)
+                if b:
+                    q.apply_x()
+                if k:
+                    q.apply_x()
+                bits_cifrados.append(q.measure())
+            resultado.append(_byte_from_bits(bits_cifrados))
+        return bytes(resultado)
+
+    def decrypt(self, key: bytes, ciphertext: bytes) -> bytes:
+        """Decripta revertendo as opera\u00e7\u00f5es de :meth:`encrypt`."""
+        return self.encrypt(key, ciphertext)
+

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+# Permite importar o pacote diretamente do diret\u00f3rio pai durante os testes
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from cryptoquantum.pqc import generate_keypair
+from cryptoquantum.simulator import QuantumSimulator
+
+
+def test_simulator_encrypt_decrypt():
+    """Valida cifragem e decifragem usando o simulador qu\u00e2ntico."""
+    pub, priv = generate_keypair()
+    sim = QuantumSimulator()
+    mensagem = b"quantum"
+    cifrado = sim.encrypt(pub, mensagem)
+    assert cifrado != mensagem
+    assert sim.decrypt(priv, cifrado) == mensagem
+


### PR DESCRIPTION
## Summary
- expand `Qubit` with `apply_x` to model Pauli-X
- add `QuantumSimulator` for a basic quantum encryption demo
- expose new module in package
- test encryption/decryption with the simulator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c3f6de40832893aedf1e6e47f416