### PR TITLE
Add verbose encryption logging in tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -21,4 +21,4 @@ jobs:
         pip install pytest
     - name: Run tests
       run: |
-        pytest -q
+        pytest -s -v

--- a/tests/test_pqc.py
+++ b/tests/test_pqc.py
@@ -13,8 +13,16 @@ def test_encrypt_decrypt():
     pub, priv = pqc.generate_keypair()
     mensagem = b"teste"
 
+    print("Mensagem antes da criptografia:", mensagem)
+    print("Iniciando processo de criptografia")
+
     # Encripta a mensagem usando a chave "pública"
     cifrado = pqc.encrypt(pub, mensagem)
 
+    print("Durante a criptografia: dados cifrados ->", cifrado.hex())
+
     # A função decripta deve retornar o texto original
-    assert pqc.decrypt(priv, cifrado) == mensagem
+    texto_plano = pqc.decrypt(priv, cifrado)
+    print("Depois da criptografia: resultado decriptado ->", texto_plano)
+
+    assert texto_plano == mensagem


### PR DESCRIPTION
## Summary
- print messages before, during and after encrypt/decrypt in `test_encrypt_decrypt`
- run tests with `pytest -s -v` so logs appear in CI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c56842f48328aa657ee1905d7f74